### PR TITLE
Set _deleted to null when undeleting

### DIFF
--- a/src/Document/DeletionFlag.php
+++ b/src/Document/DeletionFlag.php
@@ -52,8 +52,8 @@ trait DeletionFlag
     public function undelete()
     {
         if ($this->_deleted) {
-            static::getCollection()->update(['_id' => $this->_id], ['$set' => ['_deleted' => false]]);
-            $this->_deleted = false;
+            static::getCollection()->update(['_id' => $this->_id], ['$set' => ['_deleted' => null]]);
+            $this->_deleted = null;
         }
         
         return $this;


### PR DESCRIPTION
@jasny 
`undelete()` currently sets `_deleted` to `false`. Deleted documents should be set to `null`, or else they are not properly fetched through `fetchDeleted`.