### PR TITLE
Cast id when deleting document

### DIFF
--- a/src/Document/BasicImplementation.php
+++ b/src/Document/BasicImplementation.php
@@ -148,7 +148,7 @@ trait BasicImplementation
      */
     public function delete(array $opts = [])
     {
-        $filter = [static::getIdProperty() => $this->getId()];
+        $filter = [static::getIdProperty() => $this->childEntityToId($this)];
         $query = static::mapToFields($filter);
         
         static::getCollection()->remove($query);

--- a/src/Document/BasicImplementation.php
+++ b/src/Document/BasicImplementation.php
@@ -148,7 +148,8 @@ trait BasicImplementation
      */
     public function delete(array $opts = [])
     {
-        $filter = [static::getIdProperty() => $this->childEntityToId($this)];
+        $properties = [static::getIdProperty() => $this->getId()];
+        $filter = static::castForDB($properties);
         $query = static::mapToFields($filter);
         
         static::getCollection()->remove($query);


### PR DESCRIPTION
When deleting documents the id is not being casted in the `delete()` function. See the example below.

#### Model
```php
<?php

use Jasny\DB\Entity\Dynamic;
use Jasny\ValidationResult;

/**
 * Group entity
 */
class Group extends MongoDocument implements Dynamic
{  
    /**
     * @var string
     * @dbFieldType \MongoId
     * @immutable
     */
    public $id;
    ...
```

#### Controller
```php
<?php
...
$group->delete();
// the filter to delete now equals ['_id' => '000000000000000000000001']
// the id is a string instead of a MongoId
```

Using `castForDB()` on the filter fixes this.